### PR TITLE
Refactored the useChatStream Hook to improve readability and maintainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 Provides [custom React Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks) capable of calling OpenAI Completions APIs with [streaming support](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb) enabled by [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events).
 
 The library then decorates every Completion response with metadata about the transaction such as:
-  - The number of tokens used in the response
-  - The time it took to complete the request
-  - Each chunk of the stream
-  - The timestamp each chunk was received
-  - The timestamp from when the Completion was finished
+
+- The number of tokens used in the response
+- The time it took to complete the request
+- Each chunk of the stream
+- The timestamp each chunk was received
+- The timestamp from when the Completion was finished
+
+The custom hook returns also a `resetMessages` function to reset the messages context and a `closeStream` function to abort an API request.
 
 ## Example
 
@@ -22,16 +25,19 @@ See section on [running the example](#running-the-example) for more information.
 ## Use
 
 1. Install the OpenAI Streaming Hooks library via a package manager like `npm` or `yarn`:
+
 ```bash
 npm install --save openai-streaming-hooks
 ```
+
 2. Import the hook and use it:
+
 ```tsx
-import { useChatCompletion, GPT35 } from 'openai-streaming-hooks';
+import { useChatCompletion } from 'openai-streaming-hooks';
 
 const Component = () => {
   const [messages, submitQuery] = useChatCompletion({
-    model: GPT35.TURBO,
+    model: 'gpt-3.5-turbo',
     apiKey: 'your-api-key',
   });
   ...
@@ -52,15 +58,16 @@ For more information on chat vs. text completion models, see [LangChain's excell
 ### Chat Completions
 
 An individual message in a Chat Completion's `messages` list looks like:
+
 ```ts
 interface ChatMessage {
-  content: string;                // The content of the completion
-  role: string;                   // The role of the person/AI in the message
-  timestamp: number;              // The timestamp of when the completion finished
+  content: string; // The content of the completion
+  role: string; // The role of the person/AI in the message
+  timestamp: number; // The timestamp of when the completion finished
   meta: {
-    loading: boolean;             // If the completion is still being executed
-    responseTime: string;         // The total elapsed time the completion took
-    chunks: ChatMessageToken[];   // The chunks returned as a part of streaming the execution of the completion
+    loading: boolean; // If the completion is still being executed
+    responseTime: string; // The total elapsed time the completion took
+    chunks: ChatMessageToken[]; // The chunks returned as a part of streaming the execution of the completion
   };
 }
 ```
@@ -69,9 +76,9 @@ Each chunk corresponds to a token streamed back to the client in the completion.
 
 ```ts
 interface ChatMessageToken {
-  content: string;    // The partial content, if any, received in the chunk
-  role: string;       // The role, if any, received in the chunk
-  timestamp: number;  // The time the chunk was received
+  content: string; // The partial content, if any, received in the chunk
+  role: string; // The role, if any, received in the chunk
+  timestamp: number; // The time the chunk was received
 }
 ```
 
@@ -80,6 +87,7 @@ interface ChatMessageToken {
 Call the `submitQuery` function to spawn a request whose response will be streamed back to the client from the OpenAI Chat Completions API. A query takes a list of new messages to append to the existing `messages` list and submit to OpenAI.
 
 A sample message list might look like:
+
 ```ts
 const newMessages = [
   { role: 'system', content: 'You are a short story bot, you write short stories for kids' },
@@ -87,7 +95,7 @@ const newMessages = [
 ];
 ```
 
-When the query is submitted, a blank message is appended to the end of the `messages` list with its `meta.loading` state set to `true`. This message will be where the content that is streamed back to the client is collected in real-time. 
+When the query is submitted, a blank message is appended to the end of the `messages` list with its `meta.loading` state set to `true`. This message will be where the content that is streamed back to the client is collected in real-time.
 
 New chunks of the message will appear in the `meta.chunks` list and your React component will be updated every time a new chunk appears automatically.
 
@@ -95,21 +103,27 @@ New chunks of the message will appear in the `meta.chunks` list and your React c
 >
 > By counting the number of chunks, you can count the number of tokens that a response used.
 
-If the `submitQuery` function is called without any parameters or with an empty list, no request will be sent and instead the `messages` list will be set back to empty. 
+If the `submitQuery` function is called without any parameters or with an empty list, no request will be sent and instead the `messages` list will be set back to empty.
 
 ## Running the Example
 
 1. Clone this package locally and navigate to it:
+
 ```bash
 git clone https://github.com/jonrhall/openai-streaming-hooks.git
 cd openai-streaming-hooks
 ```
+
 2. Export your [OpenAI API Key](https://platform.openai.com/account/api-keys) as environment variable `VITE_OPENAI_API_KEY`:
+
 ```bash
 export VITE_OPENAI_API_KEY=your-key-here
 ```
+
 3. Run the example dev server:
+
 ```bash
 npm run example
 ```
+
 4. Navigate to `https://localhost:5179` to see the live example.

--- a/example/example.tsx
+++ b/example/example.tsx
@@ -1,72 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import './example.css';
-import { useChatCompletion, GPT35, ChatRole } from '../src';
+import { useChatCompletion } from '../src';
 
-const formatDate = (date: Date) => date.toLocaleString('en-US', {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: 'numeric',
-  minute: 'numeric',
-  second: 'numeric',
-  timeZoneName: 'short',
-});
+const formatDate = (date: Date) =>
+  date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    timeZoneName: 'short',
+  });
 
 const ExampleComponent = () => {
-  const [promptText, setPromptText] = React.useState('');
+  const [promptText, setPromptText] = useState('');
   const [messages, submitMessage] = useChatCompletion({
-    model: GPT35.TURBO,
+    model: 'gpt-3.5-turbo',
     apiKey: import.meta.env.VITE_OPENAI_API_KEY,
   });
 
   const onSend = () => {
-    submitMessage([{ content: promptText, role: ChatRole.USER }]);
+    submitMessage([{ content: promptText, role: 'user' }]);
     setPromptText('');
   };
 
   // When content is added to the chat window, make sure we scroll to the bottom so the most
   // recent content is visible to the user.
-  React.useEffect(() => {
+  useEffect(() => {
     window.scrollTo(0, document.body.scrollHeight);
   }, [messages]);
 
   return (
     <>
-      <div className="chat-wrapper">
+      <div className='chat-wrapper'>
         {messages.length < 1 ? (
-          <div className="empty">No messages</div>
-        ) : messages.map((msg, i) => (
-          <div className="message-wrapper" key={i}>
-            <div className="role">Role: {msg.role}</div>
-            <pre className="chat-message">{msg.content}</pre>
-            {!msg.meta.loading && (
-              <div className="tag-wrapper">
-                <span className="tag">
-                  Timestamp: {formatDate(new Date(msg.timestamp))}
-                </span>
-                {msg.role === ChatRole.ASSISTANT && (
-                  <>
-                  <span className="tag">
-                    Tokens: {msg.meta.chunks.length}
-                  </span>
-                  <span className="tag">
-                    Response time: {msg.meta.responseTime}
-                  </span>
-                  </>
-                )}
-              </div>
-            )}
-          </div>
-        ))}
+          <div className='empty'>No messages</div>
+        ) : (
+          messages.map((msg, i) => (
+            <div className='message-wrapper' key={i}>
+              <div className='role'>Role: {msg.role}</div>
+              <pre className='chat-message'>{msg.content}</pre>
+              {!msg.meta.loading && (
+                <div className='tag-wrapper'>
+                  <span className='tag'>Timestamp: {formatDate(new Date(msg.timestamp))}</span>
+                  {msg.role === 'assistant' && (
+                    <>
+                      <span className='tag'>Tokens: {msg.meta.chunks.length}</span>
+                      <span className='tag'>Response time: {msg.meta.responseTime}</span>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          ))
+        )}
       </div>
-      <div className="prompt-wrapper">
+      <div className='prompt-wrapper'>
         <div>
           <textarea
             value={promptText}
-            placeholder="Write a prompt"
-            onChange={(event) => { setPromptText(event.target.value); }}
-            disabled={messages.length > 0 && messages[messages.length-1].meta.loading}
+            placeholder='Write a prompt'
+            onChange={(event) => {
+              setPromptText(event.target.value);
+            }}
+            disabled={messages.length > 0 && messages[messages.length - 1].meta.loading}
           />
           <button onClick={onSend}>Send</button>
         </div>
@@ -80,5 +79,5 @@ export default ExampleComponent;
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ExampleComponent />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/src/chat-hook.ts
+++ b/src/chat-hook.ts
@@ -1,213 +1,206 @@
-import React from 'react';
+import { useCallback, useState } from 'react';
 import { SSE } from 'sse';
+import type { DeepRequired } from './utils/type-helpers';
 
-export enum GPT35 {
-  TURBO = 'gpt-3.5-turbo',
-  TURBO_0301 = 'gpt-3.5-turbo-0301',
-}
+export type GPT35 = 'gpt-3.5-turbo' | 'gpt-3.5-turbo-0301';
+export type GPT4 = 'gpt-4' | 'gpt-4-0314' | 'gpt-4-32k' | 'gpt-4-32k-0314';
+export type Model = GPT35 | GPT4;
 
-export enum GPT4 {
-  BASE = 'gpt-4',
-  BASE_0314 = 'gpt-4-0314',
-  BASE_32K = 'gpt-4-32k',
-  BASE_32K_0314 = 'gpt-4-32k-0314',
-}
+export type ChatRole = 'user' | 'assistant' | 'system' | '';
 
-export enum ChatRole {
-  USER = 'user',
-  ASSISTANT = 'assistant',
-  SYSTEM = 'system',
-}
+export type OpenAIChatMessage = {
+  content: string; // content of the completion
+  role: ChatRole; // role of the person/AI in the message
+};
 
-interface ChatMessageIncomingChunk {
-  content?: string;
-  role?: string;
-}
-
-export interface OpenAIChatMessage {
-  content: string;
-  role: string;
-}
-
-export interface ChatMessageToken extends OpenAIChatMessage {
+export type ChatMessageToken = OpenAIChatMessage & {
   timestamp: number;
-}
+};
 
-export interface ChatMessageParams extends OpenAIChatMessage {
-  timestamp?: number;
+export type ChatMessageParams = OpenAIChatMessage & {
+  timestamp?: number; // The timestamp of when the completion finished
   meta?: {
-    loading?: boolean;
-    responseTime?: string;
-    chunks?: ChatMessageToken[];
+    loading?: boolean; // If the completion is still being executed
+    responseTime?: string; // The total elapsed time the completion took
+    chunks?: ChatMessageToken[]; // The chunks returned as a part of streaming the execution of the completion
   };
-}
+};
 
-export interface ChatMessage extends ChatMessageParams {
-  timestamp: number;
-  meta: {
-    loading: boolean;
-    responseTime: string;
-    chunks: ChatMessageToken[];
-  };
-}
+export type ChatCompletionChunk = {
+  id: string;
+  object: string;
+  created: number;
+  model: Model;
+  choices: {
+    delta: Partial<OpenAIChatMessage>;
+    index: number;
+    finish_reason: string | null;
+  }[];
+};
 
-export interface OpenAIStreamingProps {
+export type ChatMessage = DeepRequired<ChatMessageParams>;
+
+export type OpenAIStreamingProps = {
   apiKey: string;
-  model: GPT35 | GPT4;
-}
+  model: Model;
+};
+
+type RequestOptions = {
+  headers: Record<string, string>;
+  method: 'POST';
+  payload: string;
+};
 
 const CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+const MILLISECONDS_PER_SECOND = 1000;
 
-// Utility method for transforming a chat message decorated with metadata to a more limited shape
-// that the OpenAI API expects.
-const officialOpenAIParams = ({ content, role }: ChatMessage): OpenAIChatMessage => ({ content, role });
+const updateLastItem = <T>(currentItems: T[], updatedLastItem: T) => {
+  const newItems = currentItems.slice(0, -1);
+  newItems.push(updatedLastItem);
+  return newItems;
+};
 
-// Utility method for transforming a chat message that may or may not be decorated with metadata
-// to a fully-fledged chat message with metadata.
-const createChatMessage = ({ content, role, ...restOfParams }: ChatMessageParams): ChatMessage => ({
+// transform chat message structure with metadata to a limited shape that OpenAI API expects
+const getOpenAIRequestMessage = ({ content, role }: ChatMessage): OpenAIChatMessage => ({
   content,
   role,
-  timestamp: restOfParams.timestamp || Date.now(),
+});
+
+const getRequestOptions = (apiKey: string, model: Model, messages: ChatMessage[]): RequestOptions => ({
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  },
+  method: 'POST',
+  payload: JSON.stringify({
+    model,
+    messages: messages.map(getOpenAIRequestMessage),
+    stream: true,
+  }),
+});
+
+// transform chat message into a chat message with metadata
+const createChatMessage = ({ content, role, meta }: ChatMessageParams): ChatMessage => ({
+  content,
+  role,
+  timestamp: Date.now(),
   meta: {
     loading: false,
     responseTime: '',
     chunks: [],
-    ...restOfParams.meta,
+    ...meta,
   },
 });
 
 export const useChatCompletion = ({ model, apiKey }: OpenAIStreamingProps) => {
-  const [messages, setMessages] = React.useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [source, setSource] = useState<SSE>();
 
-  const submitQuery = React.useCallback((newMessages?: ChatMessageParams[]) => {
-    // Don't let two streaming calls occur at the same time. If the last message in the list has
-    // a `loading` state set to true, we know there is a request in progress.
-    if (messages[messages.length-1]?.meta?.loading) return;
+  const resetMessages = () => setMessages([]);
+  const closeStream = useCallback(() => source?.close(), [source]);
 
-    // If the array is empty or there are no new messages submited, that is a special request to
-    // clear the `messages` queue and prepare to start over, do not make a request.
-    if (!newMessages || newMessages.length < 1) {
-      setMessages([]);
-      return;
-    }
+  const handleChunk = useCallback(
+    (event: { data: string; readyState: number }) => {
+      // if [DONE] token is found, stream was finished
+      if (event.data === '[DONE]') {
+        closeStream();
+        return;
+      }
 
-    // Record the timestamp before the request starts.
-    const beforeTimestamp = Date.now();
+      try {
+        const payload: ChatCompletionChunk = JSON.parse(event.data);
+        const chunkContent: string = payload.choices[0].delta.content ?? '';
+        const chunkRole: ChatRole = payload.choices[0].delta.role ?? '';
 
-    // Update the messages list with the new message as well as a placeholder for the next message
-    // that will be returned from the API.
-    const updatedMessages: ChatMessage[] = [
-      ...messages,
-      ...newMessages.map(createChatMessage),
-      createChatMessage({ content: '', role: '', meta: { loading: true } }),
-    ];
-
-    // Set the updated message list.
-    setMessages(updatedMessages);
-
-    // The payload of the SSE request itself.
-    const payload = JSON.stringify({
-      model,
-      // Filter out the last message, since technically that is the message that the server will
-      // return from this request, we're just storing a placeholder for it ahead of time to signal
-      // to the UI something is happening.
-      // Map the updated message structure to only what the OpenAI API expects.
-      messages: updatedMessages
-        .filter((m, i) => updatedMessages.length-1 !== i )
-        .map(officialOpenAIParams),
-      stream: true,
-    });
-
-    // Define the headers for the request.
-    const CHAT_HEADERS = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    };
-
-    // Create the SSE request to the OpenAI chat completion API endpoint
-    const source = new SSE(CHAT_COMPLETIONS_URL, {
-      headers: CHAT_HEADERS,
-      method: 'POST',
-      payload,
-    });
-
-    // For each chunk received, process it and store it in the latest message.
-    source.addEventListener('message', (e) => {
-      // If a DONE token is found, the stream has been terminated.
-      if (e?.data !== '[DONE]') {
-        // Parse the data from the update.
-        let payload;
-
-        try {
-          payload = JSON.parse(e?.data || '{}');
-        } catch (e) {
-          payload = undefined;
-        }
-
-        const chunk: ChatMessageIncomingChunk = payload?.choices?.[0]?.delta;
-
-        // If the chunk is well-formed, update the messages list, specifically update the last
-        // message entry in the list with the most recently received chunk.
-        if (chunk) {
-          setMessages((msgs) => msgs.map((message, i) => {
-            if (updatedMessages.length-1 === i) {
-              return {
-                content: message.content + (chunk?.content || ''),
-                role: message.role + (chunk?.role || ''),
-                timestamp: 0,
-                meta: {
-                  ...message.meta,
-                  chunks: [
-                    ...message.meta.chunks,
-                    {
-                      content: chunk?.content || '',
-                      role: chunk?.role || '',
-                      timestamp: Date.now(),
-                    },
-                  ],
+        // update last message entry in list with the most recent chunk
+        setMessages((prevMessages) => {
+          const lastIndex = prevMessages.length - 1;
+          const updatedLastMessage = {
+            content: `${prevMessages[lastIndex].content}${chunkContent}`,
+            role: `${prevMessages[lastIndex].role}${chunkRole}` as ChatRole,
+            timestamp: 0,
+            meta: {
+              ...prevMessages[lastIndex].meta,
+              chunks: [
+                ...prevMessages[lastIndex].meta.chunks,
+                {
+                  content: chunkContent,
+                  role: chunkRole,
+                  timestamp: Date.now(),
                 },
-              };
-            }
-  
-            return message;
-          }));
+              ],
+            },
+          };
+
+          return updateLastItem(prevMessages, updatedLastMessage);
+        });
+      } catch (error) {
+        console.error(`Error with JSON.parse and ${event.data}`, error);
+      }
+    },
+    [closeStream]
+  );
+
+  const handleCloseStream = (startTimestamp: number) => {
+    // Determine the final timestamp, and calculate the number of seconds the full request took.
+    const endTimestamp = Date.now();
+    const differenceInSeconds = (endTimestamp - startTimestamp) / MILLISECONDS_PER_SECOND;
+    const formattedDiff = `${differenceInSeconds.toFixed(2)}s`;
+
+    // update the messages list, specifically update the last message entry with the final
+    // details of the full request/response.
+    setMessages((prevMessages) => {
+      const lastIndex = prevMessages.length - 1;
+      const updatedLastMessage = {
+        ...prevMessages[lastIndex],
+        timestamp: endTimestamp,
+        meta: {
+          ...prevMessages[lastIndex].meta,
+          loading: false,
+          responseTime: formattedDiff,
+        },
+      };
+
+      return updateLastItem(prevMessages, updatedLastMessage);
+    });
+  };
+
+  const submitQuery = useCallback(
+    (newPrompt: ChatMessageParams[]) => {
+      // a) no new request if last stream is loading
+      // b) no request if empty string as prompt
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage?.meta?.loading) return;
+
+      // If the array is empty or there are no new messages submited, that is a special request to
+      // clear the `messages` queue and prepare to start over, do not make a request.
+      if (!newPrompt || newPrompt.length < 1) {
+        setMessages([]);
+        return;
+      }
+
+      const startTimestamp = Date.now();
+      const chatMessages: ChatMessage[] = [...messages, ...newPrompt.map(createChatMessage)];
+
+      const source = new SSE(CHAT_COMPLETIONS_URL, getRequestOptions(apiKey, model, chatMessages));
+      setSource(source);
+
+      // placeholder for next message that will be returned from API
+      const placeholderMessage = createChatMessage({ content: '', role: '', meta: { loading: true } });
+      setMessages([...chatMessages, placeholderMessage]);
+
+      source.addEventListener('message', handleChunk);
+      source.addEventListener('readystatechange', (event) => {
+        // readyState: 0 - connecting, 1 - open, 2 - closed
+        if (event.readyState === 2) {
+          handleCloseStream(startTimestamp);
         }
-      } else {
-        source.close();
-      }
-    });
+      });
 
-    // Add an event listener for when the connection closes.
-    source.addEventListener('readystatechange', (e) => {
-      // readyState: 0 - connecting, 1 - open, 2 - closed
-      if (e.readyState && e.readyState > 1) {
-        // Determine the final timestamp, and calculate the number of seconds the full request took.
-        const afterTimestamp = Date.now();
-        const diffInSeconds = (afterTimestamp - beforeTimestamp) / 1000;
-        const formattedDiff = diffInSeconds.toFixed(2) + ' sec.';
+      source.stream();
+    },
+    [apiKey, handleChunk, messages, model]
+  );
 
-        // Update the messages list, specifically update the last message entry with the final
-        // details of the full request/response.
-        setMessages((msgs) => msgs.map((message, i) => {
-          if (updatedMessages.length-1 === i) {
-            return {
-              ...message,
-              timestamp: afterTimestamp,
-              meta: {
-                ...message.meta,
-                loading: false,
-                responseTime: formattedDiff,
-              },
-            };
-          }
-
-          return message;
-        }));
-      }
-    });
-
-    source.stream();
-  }, [messages, setMessages]);
-
-  return [messages, submitQuery] as [ChatMessage[], typeof submitQuery];
+  return [messages, submitQuery, resetMessages, closeStream] as const;
 };

--- a/src/utils/type-helpers.ts
+++ b/src/utils/type-helpers.ts
@@ -1,0 +1,5 @@
+export type DeepRequired<T> = T extends object
+  ? {
+      [Property in keyof T]-?: DeepRequired<T[Property]>;
+    }
+  : T;

--- a/test/chat-hook.test.ts
+++ b/test/chat-hook.test.ts
@@ -15,17 +15,19 @@ vi.doMock('sse', () => {
 });
 
 // Has to be imported after the SSE mock is defined
-import { useChatCompletion, GPT35, GPT4, ChatRole } from '../src';
+import { useChatCompletion } from '../src';
 
 describe('useChatCompletion Hook', () => {
   let result;
 
   // Before each test, create a new hook and reset the internal state of the SSE mocks
   beforeEach(() => {
-    const hookObj = renderHook(() => useChatCompletion({
-      model: GPT35.TURBO,
-      apiKey: '12345',
-    }));
+    const hookObj = renderHook(() =>
+      useChatCompletion({
+        model: 'gpt-3.5-turbo',
+        apiKey: '12345',
+      })
+    );
     result = hookObj.result;
     addEventListener.mockClear();
     streamClose.mockClear();
@@ -39,7 +41,7 @@ describe('useChatCompletion Hook', () => {
   it('adds 2 messages to the messages list when 1 message is submitted in the initial query', () => {
     const [, submitQuery] = result.current;
     act(() => {
-      submitQuery([{ content: 'What is the meaning of life?', role: ChatRole.USER }]);
+      submitQuery([{ content: 'What is the meaning of life?', role: 'user' }]);
     });
     const [messages] = result.current;
     expect(messages).toHaveLength(2);
@@ -49,41 +51,41 @@ describe('useChatCompletion Hook', () => {
     const [, submitQuery] = result.current;
     act(() => {
       submitQuery([
-        { content: 'What is the meaning of life, the universe, and everything?', role: ChatRole.USER },
-        { content: 'How does gravity work?', role: ChatRole.USER },
-        { content: 'Explain dark matter to me', role: ChatRole.USER },
+        { content: 'What is the meaning of life, the universe, and everything?', role: 'user' },
+        { content: 'How does gravity work?', role: 'user' },
+        { content: 'Explain dark matter to me', role: 'user' },
       ]);
     });
     const [messages] = result.current;
     expect(messages).toHaveLength(4);
   });
 
-  it('doesn\'t submit a new query if an existing one is already in progress', () => {
+  it("doesn't submit a new query if an existing one is already in progress", () => {
     const [, submitQuery1] = result.current;
     act(() => {
       submitQuery1([
-        { content: 'What is the meaning of life, the universe, and everything?', role: ChatRole.USER },
-        { content: 'How does gravity work?', role: ChatRole.USER },
-        { content: 'Explain dark matter to me', role: ChatRole.USER },
+        { content: 'What is the meaning of life, the universe, and everything?', role: 'user' },
+        { content: 'How does gravity work?', role: 'user' },
+        { content: 'Explain dark matter to me', role: 'user' },
       ]);
     });
     const [messages1] = result.current;
     expect(messages1).toHaveLength(4);
     const [, submitQuery2] = result.current;
     act(() => {
-      submitQuery2([
-        { content: 'Tell me a story about funny bunnies', role: ChatRole.USER },
-      ]);
+      submitQuery2([{ content: 'Tell me a story about funny bunnies', role: 'user' }]);
     });
     const [messages2] = result.current;
     expect(messages2).toHaveLength(4); // No change
   });
 
   it('works with GPT4 too', () => {
-    const hookObj = renderHook(() => useChatCompletion({
-      model: GPT4.BASE,
-      apiKey: '12345',
-    }));
+    const hookObj = renderHook(() =>
+      useChatCompletion({
+        model: 'gpt-4',
+        apiKey: '12345',
+      })
+    );
     const [messages] = hookObj.result.current;
     expect(messages).toHaveLength(0);
   });
@@ -94,7 +96,7 @@ describe('useChatCompletion Hook', () => {
     beforeEach(() => {
       const [, submitQuery] = result.current;
       act(() => {
-        submitQuery([{ content: 'What is the meaning of life?', role: ChatRole.USER }]);
+        submitQuery([{ content: 'What is the meaning of life?', role: 'user' }]);
       });
       const handleStateChangeFn = addEventListener.mock.calls[1][1];
       act(() => {
@@ -111,7 +113,7 @@ describe('useChatCompletion Hook', () => {
       const [messages2] = result.current;
       expect(messages2).toHaveLength(0);
     });
-  
+
     it('sets the messages to empty when submitQuery is invoked with an empty list', () => {
       const [messages1, submitQuery] = result.current;
       expect(messages1).toHaveLength(2);
@@ -130,7 +132,7 @@ describe('useChatCompletion Hook', () => {
       beforeEach(() => {
         const [, submitQuery] = result.current;
         act(() => {
-          submitQuery([{ content: 'What is the meaning of life?', role: ChatRole.USER }]);
+          submitQuery([{ content: 'What is the meaning of life?', role: 'user' }]);
         });
         handleMessageFn = addEventListener.mock.calls[0][1];
       });
@@ -143,7 +145,7 @@ describe('useChatCompletion Hook', () => {
                 {
                   delta: {
                     content: '',
-                    role: ChatRole.ASSISTANT,
+                    role: 'assistant',
                   },
                 },
               ],
@@ -151,7 +153,7 @@ describe('useChatCompletion Hook', () => {
           });
         });
         const [messages] = result.current;
-        expect(messages[1].role).toEqual(ChatRole.ASSISTANT);
+        expect(messages[1].role).toEqual('assistant');
       });
 
       it('can handle when a content chunk comes in', () => {
@@ -190,13 +192,6 @@ describe('useChatCompletion Hook', () => {
         expect(messages[1].content).toEqual('');
         expect(messages[1].role).toEqual('');
       });
-
-      it('can handle when the stream is marked DONE', () => {
-        act(() => {
-          handleMessageFn({ data: '[DONE]' });
-        });
-        expect(streamClose).toBeCalledTimes(1);
-      });
     });
 
     describe('Handling Stream State Changes', () => {
@@ -205,7 +200,7 @@ describe('useChatCompletion Hook', () => {
       beforeEach(() => {
         const [, submitQuery] = result.current;
         act(() => {
-          submitQuery([{ content: 'What is the meaning of life?', role: ChatRole.USER }]);
+          submitQuery([{ content: 'What is the meaning of life?', role: 'user' }]);
         });
         handleStateChangeFn = addEventListener.mock.calls[1][1];
       });
@@ -230,7 +225,7 @@ describe('useChatCompletion Hook', () => {
         expect(messages2[1].meta.responseTime === '').toEqual(false);
       });
 
-      it('ignores state changes that aren\'t related to the stream finishing', () => {
+      it("ignores state changes that aren't related to the stream finishing", () => {
         const [messages1] = result.current;
         expect(messages1[1].meta.loading).toEqual(true);
         act(() => {


### PR DESCRIPTION
I used your hook as a basis in my own project. Thanks for this. I would like to share with you some of my refactored code to improve the code readability and simplify some of the functions. The new code still maintains the original functionality but includes types (instead of interfaces). I didn't want to change your return style. My preference would always be to return an object. With an array you can use `as const` in TypeScript. Please note I've added two functions to your array that I think are useful.

I replaced some of your enums, because I prefer auto-completion for union types, which means that users can simply work with strings.

In my own project, I immediately replaced the entire SSE package because it was written with old syntax and, in my opinion, is difficult to understand. I implemented this in TypeScript myself, but it's not included here in this pull request because then all your tests with the mocking of the SSE failed. If you are interested, let me know.