### PR TITLE
add polyfill for readable stream async iterable support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "openai-streaming-hooks",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-streaming-hooks",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "react": "^18.2.0"
+        "react": "^18.2.0",
+        "web-streams-polyfill": "^3.2.1"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -5667,6 +5668,14 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "test:coverage": "vitest run --coverage",
     "prettier": "prettier --write ."
   },
-  "keywords": ["react", "react-hooks", "openai"],
+  "keywords": [
+    "react",
+    "react-hooks",
+    "openai"
+  ],
   "author": "jonrhall",
   "contributors": [
     {
@@ -25,7 +29,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "web-streams-polyfill": "^3.2.1"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",


### PR DESCRIPTION
Hi! 👋 As pointed out in #6, the only browser that currently supports async iterable with `ReadableStream` is Firefox:
 - https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility

This adds the [web-streams-polyfill](https://www.npmjs.com/package/web-streams-polyfill) package to fix behavior for all browsers. Confirmed working with Chrome 114.0.5735.90 and Safari 16.5.